### PR TITLE
Use actual field name instead FieldMask prefix for field mask method

### DIFF
--- a/internal/templates/go/fm.tpl
+++ b/internal/templates/go/fm.tpl
@@ -2,7 +2,7 @@
 {{ $outMessageName := .OutMessage.Name }}
 {{ $fmField := .FieldMaskField }}
 
-func (x *{{ $inMessageName }}) FieldMaskWithMode(mode pbfieldmask.MaskMode) *{{ $inMessageName }}_FieldMask {
+func (x *{{ $inMessageName }}) {{ $fmField.Name.UpperCamelCase }}_WithMode(mode pbfieldmask.MaskMode) *{{ $inMessageName }}_FieldMask {
     fm := &{{ $inMessageName }}_FieldMask{
         maskMode: mode,
         mask: pbfieldmask.New(x.{{$fmField.Name.UpperCamelCase}}),
@@ -11,18 +11,18 @@ func (x *{{ $inMessageName }}) FieldMaskWithMode(mode pbfieldmask.MaskMode) *{{ 
     return fm
 }
 
-// FieldMask_Prune generates *{{ $inMessageName }}_FieldMask with filter mode, so that
+// {{ $fmField.Name.UpperCamelCase }}_Filter generates *{{ $inMessageName }}_FieldMask with filter mode, so that
 // only the fields in the {{ $inMessageName }}.{{ $fmField.Name.UpperCamelCase }} will be
 // appended into the {{ $inMessageName }}.
-func (x *{{ $inMessageName }}) FieldMask_Filter() *{{ $inMessageName }}_FieldMask {
-	return x.FieldMaskWithMode(pbfieldmask.MaskMode_Filter)
+func (x *{{ $inMessageName }}) {{ $fmField.Name.UpperCamelCase }}_Filter() *{{ $inMessageName }}_FieldMask {
+	return x.{{ $fmField.Name.UpperCamelCase }}_WithMode(pbfieldmask.MaskMode_Filter)
 }
 
-// FieldMask_Prune generates *{{ $inMessageName }}_FieldMask with prune mode, so that
+// {{ $fmField.Name.UpperCamelCase }}_Prune generates *{{ $inMessageName }}_FieldMask with prune mode, so that
 // only the fields NOT in the {{ $inMessageName }}.{{ $fmField.Name.UpperCamelCase }} will be
 // appended into the {{ $inMessageName }}.
-func (x *{{ $inMessageName }}) FieldMask_Prune() *{{ $inMessageName }}_FieldMask {
-	return x.FieldMaskWithMode(pbfieldmask.MaskMode_Prune)
+func (x *{{ $inMessageName }}) {{ $fmField.Name.UpperCamelCase }}_Prune() *{{ $inMessageName }}_FieldMask {
+	return x.{{ $fmField.Name.UpperCamelCase }}_WithMode(pbfieldmask.MaskMode_Prune)
 }
 
 // {{ $inMessageName }}_FieldMask provide provide helper functions to deal with FieldMask.


### PR DESCRIPTION
Use actual field name prefix instead fixed FieldMaskWithMode,
FieldMask_Filter, and FieldMask_Prune names. Put underscore for
WithMode method name to make it consistent with other generated
methods. Fix generated _Filter method documentation.

Fixes #9